### PR TITLE
set *user-auth* in handle-login if necessary

### DIFF
--- a/src/hoplon/firebase/auth.cljs.hl
+++ b/src/hoplon/firebase/auth.cljs.hl
@@ -51,6 +51,7 @@
 (defn- handle-login
   [auth & [ref default]]
   (let [ref (when ref (fbdb/get-in ref (fbuser/uid auth)))]
+    (when (nil? @*user-auth*) (reset! *user-auth* auth))
     (when (and ref default)
       (hfb/fb-default ref default))
     (when ref


### PR DESCRIPTION
set the `*user-auth*` within `handle-login` so that it is correctly set when an authenticated user reloads the page. 
